### PR TITLE
pin unyt to < 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies=["numpy",
               "scipy",
               "matplotlib",
               "packaging",
-              "unyt",
+              "unyt<3.0",
  ]
 
 [tool.setuptools]


### PR DESCRIPTION
`pyVBRc/tests/test_pyVBRc.py:49: ` is failing with latest unyt release. need to adjust a few spots, so pinning unyt for now.